### PR TITLE
Add badge for android-gems.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Gems](http://www.android-gems.com/badge/DxTT/coolMenu.svg?branch=master)](http://www.android-gems.com/lib/DxTT/coolMenu)
+
 # coolMenu
 The Android implementation of [Cards Menu Concept](https://dribbble.com/shots/2389505-Cards-Menu-Concept) by [Gal Shir](https://dribbble.com/galshir).
 


### PR DESCRIPTION
Added badge for android-gems: http://www.android-gems.com/lib/DxTT/coolMenu , it looks like this:

[![Android Gems](http://www.android-gems.com/badge/DxTT/coolMenu.svg?branch=master)](http://www.android-gems.com/lib/DxTT/coolMenu)
