### PR TITLE
动画对象构造移到循环外面

### DIFF
--- a/coolmenu/src/main/java/com/dxtt/coolmenu/CoolMenuFrameLayout.java
+++ b/coolmenu/src/main/java/com/dxtt/coolmenu/CoolMenuFrameLayout.java
@@ -102,10 +102,10 @@ public final class CoolMenuFrameLayout extends FrameLayout {
                 LayoutParams layoutParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
                 frameLayout.setLayoutParams(layoutParams);
                 addView(frameLayout);
-                mOpenAnimators = new ObjectAnimator[num];
-                mChosenAnimators = new ObjectAnimator[num];
-                mMenuOpenAnimators = new ObjectAnimator[num];
             }
+            mOpenAnimators = new ObjectAnimator[num];
+            mChosenAnimators = new ObjectAnimator[num];
+            mMenuOpenAnimators = new ObjectAnimator[num];
             initAnim();
         }
     }


### PR DESCRIPTION
动画对象构造与循环无关，移动到外面去。
